### PR TITLE
Remove explicit shell + user comment from node exporter user

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,8 +31,6 @@
     name: "{{ prometheus_user }}"
     group: "{{ prometheus_group }}"
     createhome: no
-    shell: /sbin/nologin
-    comment: "Prometheus User"
     state: present
 
 - name: mkdir for general cases


### PR DESCRIPTION
This is because a customer may bring an existing user to use as the node exporter user that is also being used for something else, and needs to be able to login as this user. Without explicitly setting the shell here, Ansible will fall back to using the default shell for the useradd command (i.e. SHELL in /etc/default/useradd) if the user is being created/doesn't already exist.

Tested by manually changing this file + creating onprem universe without user existing (i.e. no regression occurs) and tested creating onprem universe with specifying the node exporter user as yugabyte (i.e. yugabyte user runs both master/tserver processes as well as node exporter) and confirmed that SSH'ing into nodes as the yugabyte user is still possible (i.e. that it's default shell was not overwritten by this code).