### PR TITLE
Hardcode node exporter version for Ansible compatibility issues

### DIFF
--- a/tasks/install-node-exporter.yml
+++ b/tasks/install-node-exporter.yml
@@ -19,22 +19,22 @@
     - name: set download url for >= 0.13
       set_fact:
         prometheus_node_exporter_tarball_url: "https://github.com/prometheus/node_exporter/releases/download/v{{ prometheus_node_exporter_version }}/{{ prometheus_node_exporter_archive_file }}"
-      when: prometheus_node_exporter_version >= 0.13
+      when: prometheus_node_exporter_version is version('0.13', '>=')
 
     - name: set download url for < 0.13
       set_fact:
         prometheus_node_exporter_tarball_url: "https://github.com/prometheus/node_exporter/releases/download/{{ prometheus_node_exporter_version }}/{{ prometheus_node_exporter_archive_file }}"
-      when: prometheus_node_exporter_version < 0.13
+      when: prometheus_node_exporter_version is version('0.13', '<')
 
     - name: set daemon dir for >= 0.12
       set_fact:
         prometheus_node_exporter_daemon_dir: "{{ prometheus_node_exporter_subdir }}"
-      when: prometheus_node_exporter_version | version_compare('0.12', '>=')
+      when: prometheus_node_exporter_version is version('0.12', '>=')
 
     - name: set daemon dir for < 0.12
       set_fact:
         prometheus_node_exporter_daemon_dir: "{{ prometheus_install_path }}"
-      when: prometheus_node_exporter_version | version_compare('0.12', '<')
+      when: prometheus_node_exporter_version is version('0.12', '<')
 
     - name: download and untar node_exporter tarball
       unarchive:

--- a/tasks/install-node-exporter.yml
+++ b/tasks/install-node-exporter.yml
@@ -16,25 +16,13 @@
         prometheus_node_exporter_subdir: "{{ prometheus_install_path }}/{{ prometheus_node_exporter_signature }}"
         prometheus_node_exporter_archive_file: "{{ prometheus_node_exporter_signature }}.tar.gz"
 
-    - name: set download url for >= 0.13
+    - name: set download url for >= 0.13 # Node exporter version is set to 0.13.0
       set_fact:
         prometheus_node_exporter_tarball_url: "https://github.com/prometheus/node_exporter/releases/download/v{{ prometheus_node_exporter_version }}/{{ prometheus_node_exporter_archive_file }}"
-      when: prometheus_node_exporter_version is version('0.13', '>=')
 
-    - name: set download url for < 0.13
-      set_fact:
-        prometheus_node_exporter_tarball_url: "https://github.com/prometheus/node_exporter/releases/download/{{ prometheus_node_exporter_version }}/{{ prometheus_node_exporter_archive_file }}"
-      when: prometheus_node_exporter_version is version('0.13', '<')
-
-    - name: set daemon dir for >= 0.12
+    - name: set daemon dir for >= 0.12 # Node exporter version is set to 0.13.0
       set_fact:
         prometheus_node_exporter_daemon_dir: "{{ prometheus_node_exporter_subdir }}"
-      when: prometheus_node_exporter_version is version('0.12', '>=')
-
-    - name: set daemon dir for < 0.12
-      set_fact:
-        prometheus_node_exporter_daemon_dir: "{{ prometheus_install_path }}"
-      when: prometheus_node_exporter_version is version('0.12', '<')
 
     - name: download and untar node_exporter tarball
       unarchive:


### PR DESCRIPTION
After upgrading ansible to 2.5 on platform, there were some some compatibility issues with version checks. Since we only use Node Exporter 0.13.0 and will rarely upgrade, we can just hardcode the variables in.