### PR TITLE
Add support for Suse

### DIFF
--- a/tasks/install-node-exporter.yml
+++ b/tasks/install-node-exporter.yml
@@ -101,7 +101,7 @@
   when: not prometheus_node_exporter_use_systemd|bool
 
 - name: copy systemd config to server
-  template: src="../templates/node_exporter.service.j2"  dest="/lib/systemd/system/node_exporter.service"
+  template: src="../templates/node_exporter.service.j2"  dest="/usr/lib/systemd/system/node_exporter.service"
   when: prometheus_node_exporter_use_systemd
 
 


### PR DESCRIPTION
Add support for Suse by changing the systemd unit file location
to the /usr directory. Verified that the same directory also
exists for other OS flavors.
