### PR TITLE
[PLAT-7523] Revert to use /lib/systemd/system for system systemd units

### DIFF
--- a/tasks/install-node-exporter.yml
+++ b/tasks/install-node-exporter.yml
@@ -101,7 +101,7 @@
   when: not prometheus_node_exporter_use_systemd|bool
 
 - name: copy systemd config to server
-  template: src="../templates/node_exporter.service.j2"  dest="/usr/lib/systemd/system/node_exporter.service"
+  template: src="../templates/node_exporter.service.j2"  dest="/lib/systemd/system/node_exporter.service"
   when: prometheus_node_exporter_use_systemd
 
 


### PR DESCRIPTION
SLES stores systemd units under /usr/lib/systemd/system instead of
/lib/systemd/system. We noticed that in all OSs both these directories
are mirror images and therefore while introducing support for SLES
we referred to /user/lib/systemd/system for system units. However,
we found that Ubuntu 18 was an exception in which /usr/lib/systemd/system
didn't exist.

This change reverts back to using /lib/systemd/system for all OSs.
In SLES we create a soft-link from /usr/lib/systemd/system to
/lib/systemd/system in pre-provisioning ansible playbook.

TEST PLAN
  Created 1-node universe on SLES/Ubuntu-20/Ubuntu-18/Alma/Centos
