### PR TITLE
[PLAT-7523] Handle system specific systemd units in SLES

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,3 +55,4 @@ prometheus_rebuild:           false
 prometheus_node_exporter_use_systemd: true
 prometheus_use_systemd: true
 prometheus_alertmanager_use_systemd: true
+prometheus_systemd_unit_dir: /lib/systemd/system

--- a/tasks/install-node-exporter.yml
+++ b/tasks/install-node-exporter.yml
@@ -101,7 +101,7 @@
   when: not prometheus_node_exporter_use_systemd|bool
 
 - name: copy systemd config to server
-  template: src="../templates/node_exporter.service.j2"  dest="/usr/lib/systemd/system/node_exporter.service"
+  template: src="../templates/node_exporter.service.j2"  dest={{ prometheus_systemd_unit_dir }}/node_exporter.service
   when: prometheus_node_exporter_use_systemd
 
 

--- a/tasks/set-role-variables.yml
+++ b/tasks/set-role-variables.yml
@@ -34,6 +34,10 @@
 
   when: prometheus_node_exporter_use_systemd is not defined
 
+- name: configure prometheus_systemd_unit_dir for SLES
+  set_fact:
+    prometheus_systemd_unit_dir: "/usr/lib/systemd/system"
+  when: ansible_distribution == "SLES" and prometheus_node_exporter_use_systemd == True
 
 - name: use traditional SysV init, otherwise
   set_fact:


### PR DESCRIPTION
SLES stores systemd units under /usr/lib/systemd/system instead of
/lib/systemd/system. We noticed that in all OSs both these directories
are mirror images and therefore while introducing support for SLES
we referred to /user/lib/systemd/system for system units. However,
we found that Ubuntu 18 was an exception in which /usr/lib/systemd/system
didn't exist.

This change reverts back to using /lib/systemd/system for all OSs.
We dynamically change the systemd unit base directory in SLES to
/usr/lib/systemd/system.

Test plan: Created 1-node universe on SLES/Ubuntu-20/Ubuntu-18/Alma/Centos
