### PR TITLE
[PLAT-6985] Make node exporter restart automatically on failure

### DIFF
--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -2,6 +2,8 @@
 Description=node_exporter - Exporter for machine metrics.
 Documentation=https://github.com/William-Yeh/ansible-prometheus
 After=network.target
+StartLimitInterval=100
+StartLimitBurst=10
 
 [Install]
 WantedBy=multi-user.target
@@ -22,3 +24,5 @@ ExecStart={{ prometheus_node_exporter_daemon_dir }}/node_exporter  {{ prometheus
 {% else %}
 ExecStart={{ prometheus_node_exporter_daemon_dir }}/node_exporter
 {% endif %}
+Restart=on-failure
+RestartSec=5


### PR DESCRIPTION
Make node exporter server restart on failures, similar to yb-master and yb-tserver services.

Test plan:
1. Create universe with changed node_exporter service template.
2. SSH to DB node.
3. Kill node_exporter process. Make sure process is restarted.