### PR TITLE
[PLAT-8144] Don't install libselinux in air_gap

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,7 @@
     name: libselinux-python
     state: present
     lock_timeout: 600
-  when: ansible_pkg_mgr == "yum"
+  when: not air_gap and ansible_pkg_mgr == "yum"
 
 - name: install dependencies for compiling Prometheus source code
   include_tasks: install-compile-tools.yml


### PR DESCRIPTION
Skip libselinux install step for air gap 